### PR TITLE
proof of concept python extension for frcw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ target/
 .*.swo
 ~*~
 .DS_Store
+
+# python nonsense
+activate/
+build/
+dist/
+*.egg-info
+
+# JetBrains IDE workspace settings
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
@@ -48,9 +48,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blas-src"
@@ -60,25 +60,18 @@ checksum = "a25f136d1bcc6fc28330077511a0646aaf75bc894e5532b1a33a93d814272328"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -88,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "cast"
@@ -124,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -136,9 +129,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -254,6 +247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,7 +263,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -277,10 +279,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
+ "block-buffer",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -305,6 +309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,9 +322,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "frcw"
@@ -330,19 +340,21 @@ dependencies = [
  "ndarray-linalg",
  "pcompress",
  "petgraph",
+ "pyo3",
  "rand 0.8.4",
  "rstest",
  "serde",
  "serde_json",
  "sha3",
+ "snafu",
  "test_fixtures",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -372,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -402,34 +414,72 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.1"
+name = "indoc"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
+dependencies = [
+ "indoc-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "indoc-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unindent",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -481,17 +531,26 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1b8479c593dba88c2741fc50b92e13dbabbbe0bd504d979f244ccc1a5b1c01"
+checksum = "9636c194f9db483f4d0adf2f99a65011a99f904bd222bbd67fb4df4f37863c30"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -514,24 +573,24 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mimalloc"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb74897ce508e6c49156fd1476fc5922cbc6e75183c65e399c765a09122e5130"
+checksum = "cf5f78c1d9892fb5677a8b2f543f967ab891ac0f71feecd961435b74f877283a"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -599,25 +658,25 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openblas-build"
@@ -638,6 +697,50 @@ dependencies = [
  "dirs",
  "openblas-build",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -700,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -729,19 +832,73 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.28"
+name = "proc-macro-hack"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.9"
+name = "pyo3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "parking_lot",
+ "paste",
+ "pyo3-build-config",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+dependencies = [
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
+dependencies = [
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -931,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -976,18 +1133,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -995,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,25 +1163,51 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
 dependencies = [
- "block-buffer",
  "digest",
  "keccak",
- "opaque-debug",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "snafu"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eba135d2c579aa65364522eb78590cdf703176ef71ad4c32b00f58f7afb2df5"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7fe9b0669ef117c5cabc5549638528f36771f058ff977d7689deb517833a75"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1059,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1086,18 +1269,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1116,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -1134,15 +1317,21 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "vcpkg"
@@ -1158,9 +1347,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1187,9 +1376,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1197,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1212,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1222,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1235,15 +1424,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,24 @@ version = "0.1.0"
 authors = ["Parker J. Rule <parker.rule@tufts.edu>"]
 edition = "2018"
 
+[package.metadata.maturin]
+python-source = "python_src"
+
 [dependencies]
-serde = { version = "1.0.64", features = ["derive"] }
-serde_json = "1.0.64"
-clap = "2.33.3"
-rand = { version = "0.8.3", features = ["small_rng"] }
-mimalloc = { version = "0.1.25", default-features = false }
+clap = "2.33.4"
 crossbeam-channel = "0.5.0"
 crossbeam = "0.8.0"
-sha3 = "0.9.1"
-petgraph = "0.6.0"
+mimalloc = {version = "0.1.27", default-features=false}
 ndarray = { version = "0.14", optional = true }
 ndarray-linalg = { version = "0.13", features = ["openblas-system"], optional = true }
 pcompress = "1.0.6"
+petgraph = "0.6.0"
+pyo3 = { version = "0.15.1", features = ["extension-module"] }
+rand = { version = "0.8.3", features = ["small_rng"] }
+serde = { version = "1.0.64", features = ["derive"] }
+serde_json = "1.0.64"
+sha3 = "0.10.0"
+snafu = "0.7.0"
 
 [dev-dependencies]
 rstest = "0.10.0"
@@ -43,3 +48,7 @@ debug = false
 lto = true
 codegen-units = 1
 panic = "abort"
+
+[lib]
+name = "frcw"
+crate-type = ["cdylib", "rlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"

--- a/python_src/__init__.py
+++ b/python_src/__init__.py
@@ -1,0 +1,1 @@
+from ._frcw import *

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,33 +1,70 @@
 //! A lightweight graph with population metadata.
 use std::cmp::{max, min};
 use std::collections::HashMap;
+use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
+use snafu::prelude::*;
+
 
 /// Edges are pairs of node indices.
+#[pyclass]
 #[derive(Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct Edge(pub usize, pub usize);
 
+#[derive(Debug, Snafu)]
+pub enum GraphError {
+    #[snafu(display("Empty edge list"))]
+    ErrEmptyEdgeList,
+    #[snafu(display("Could not parse edge index: {edge_index}"))]
+    ErrEdgeIndexParse { edge_index: String},
+    #[snafu(display("Invalid line in edge list: {line}"))]
+    ErrEdgeListLine { line: String},
+    #[snafu(display("Edges must be 0-indexed or 1-indexed, but minimum index is {value}"))]
+    ErrEdgeIndexMinimumValue {value: usize},
+    #[snafu(display("Duplicate edge: {e0} {e1}"))]
+    ErrDuplicateEdge { e0: usize, e1: usize },
+    #[snafu(display("Mismatch: edge list has {edge_list_nodes} nodes, population list has {pop_list_nodes} nodes"))]
+    ErrNodeLengthMismatch {edge_list_nodes: usize, pop_list_nodes: usize},
+    #[snafu(display("Could not parse population value: {pop}"))]
+    ErrPopulationParse {pop: String },
+}
+
+impl std::convert::From<GraphError> for PyErr {
+    fn from(err: GraphError) -> PyErr {
+        PyValueError::new_err(err.to_string())
+    }
+}
+
 /// A lightweight graph with population metadata.
+#[pyclass]
 #[derive(Clone)]
 pub struct Graph {
     /// The graph's edges, represented as pairs of node indices,
     /// sorted by the first element of the pair.
     /// (Nodes are represented implicitly.)
+    #[pyo3(get, set)]
     pub edges: Vec<Edge>,
     /// The population at each node.
+    #[pyo3(get, set)]
     pub pops: Vec<u32>,
     /// The graph's adjacencies (list-of-lists format).
+    #[pyo3(get, set)]
     pub neighbors: Vec<Vec<usize>>,
     /// Maps between node indices and blocks of edges in `edges`.
     /// The nth element corresponds to the starting index of the
     /// block of edges in `edges` of the form (n, *).
+    #[pyo3(get, set)]
     pub edges_start: Vec<usize>,
     /// The total population over all nodes.
     /// (Should be equal to the sum of `pops`.)
+    #[pyo3(get, set)]
     pub total_pop: u32,
     /// Additional node attributes (optional).
+    #[pyo3(get, set)]
     pub attr: HashMap<String, Vec<u32>>,
 }
 
+// functions/methods implemented only for rust
 impl Graph {
     /// Returns a new graph with preallocated containers for `n` nodes and
     /// `8 * n` edges.
@@ -40,109 +77,6 @@ impl Graph {
             total_pop: 0,
             attr: HashMap::new(),
         }
-    }
-
-    /// Initializes a graph from a newline-delimited edge list format representation.
-    ///
-    /// Arguments:
-    ///   * `edge_list`: The list of edges in the graph. Each line contains
-    ///     two indices delimited by a space. Nodes are assumed to be labeled
-    ///     0..n-1 or 1..n. No edge ordering is assumed.
-    ///   * `populations`: The integer population of each node in the graph,
-    ///     in index order.
-    ///
-    /// If the edge list or populations cannot be parsed, or if the number
-    /// of nodes is inconsistent between `edge_lists` and `populations`,
-    /// and `Err` is returned. Empty graphs are considered invalid, as are
-    /// graphs with duplicate edges.
-    ///
-    /// The caller is responsible for ensuring the graph is connected
-    /// (if that property is desired).
-    pub fn from_edge_list(edge_list: &str, populations: &str) -> Result<Graph, String> {
-        let mut edges = Vec::<Edge>::new();
-        if edge_list.is_empty() {
-            return Err("Empty edge list".to_string());
-        }
-        for line in edge_list.split('\n') {
-            if line.is_empty() {
-                continue;
-            }
-            let indices: Vec<&str> = line.split(' ').collect();
-            if indices.len() != 2 {
-                return Err(format!("Invalid line in edge list: {}", line));
-            }
-            let src = match indices[0].parse::<usize>() {
-                Ok(idx) => idx,
-                Err(_) => return Err(format!("Could not parse edge index: {}", indices[0])),
-            };
-            let dst = match indices[1].parse::<usize>() {
-                Ok(idx) => idx,
-                Err(_) => return Err(format!("Could not parse edge index: {}", indices[1])),
-            };
-            edges.push(Edge(min(src, dst), max(src, dst)));
-        }
-        let min_index = edges.iter().map(|e| e.0).min().unwrap();
-        let max_index = edges.iter().map(|e| e.1).max().unwrap();
-        let n;
-        if min_index == 0 {
-            n = max_index + 1;
-        } else if min_index == 1 {
-            // Fix 1-indexing.
-            n = max_index;
-            edges = edges.iter().map(|e| Edge(e.0 - 1, e.1 - 1)).collect();
-        } else {
-            return Err(format!(
-                "Edges must be 0-indexed or 1-indexed, but minimum index is {}",
-                min_index
-            ));
-        }
-        edges.sort();
-        let mut edges_start = Vec::<usize>::new();
-        let mut neighbors = vec![Vec::<usize>::new(); n];
-        let mut src = edges[0].0;
-        edges_start.push(0);
-        for (idx, edge) in edges.iter().enumerate() {
-            if edge.0 != src {
-                // Handle implicit nodes with no edges.
-                for _ in src..edge.0 {
-                    edges_start.push(idx);
-                }
-                src = edge.0;
-            }
-            if neighbors[edge.0].contains(&edge.1) {
-                return Err(format!("Duplicate edge: {} {}", edge.0 + 1, edge.1 + 1));
-            }
-            neighbors[edge.0].push(edge.1);
-            neighbors[edge.1].push(edge.0);
-        }
-        // Handle implicit nodes with no edges.
-        for _ in src..n - 1 {
-            edges_start.push(edges.len());
-        }
-
-        let mut parsed_pops = Vec::<u32>::with_capacity(neighbors.len());
-        for pop in populations.replace('\n', "").split(' ') {
-            match pop.parse::<u32>() {
-                Ok(parsed) => parsed_pops.push(parsed),
-                Err(_) => return Err(format!("Could not parse population value: {}", pop)),
-            }
-        }
-        if parsed_pops.len() != neighbors.len() {
-            return Err(format!(
-                "Mismatch: edge list has {} nodes, population list has {} nodes",
-                neighbors.len(),
-                parsed_pops.len()
-            ));
-        }
-
-        Ok(Graph {
-            total_pop: parsed_pops.iter().sum(),
-            pops: parsed_pops,
-            neighbors: neighbors,
-            edges: edges,
-            edges_start: edges_start,
-            attr: HashMap::new(),
-        })
     }
 
     /// Returns an nXm rectangular grid graph with unit population at each node.
@@ -188,6 +122,121 @@ impl Graph {
         }
     }
 
+    /// Initializes a graph from a newline-delimited edge list format representation.
+    ///
+    /// Arguments:
+    ///   * `edge_list`: The list of edges in the graph. Each line contains
+    ///     two indices delimited by a space. Nodes are assumed to be labeled
+    ///     0..n-1 or 1..n. No edge ordering is assumed.
+    ///   * `populations`: The integer population of each node in the graph,
+    ///     in index order.
+    ///
+    /// If the edge list or populations cannot be parsed, or if the number
+    /// of nodes is inconsistent between `edge_lists` and `populations`,
+    /// and `Err` is returned. Empty graphs are considered invalid, as are
+    /// graphs with duplicate edges.
+    ///
+    /// The caller is responsible for ensuring the graph is connected
+    /// (if that property is desired).
+    pub fn from_edge_list(edge_list: &str, populations: &str) -> Result<Graph, GraphError> {
+        let mut edges = Vec::<Edge>::new();
+        if edge_list.is_empty() {
+            return Err(GraphError::ErrEmptyEdgeList);
+        }
+        for line in edge_list.split('\n') {
+            if line.is_empty() {
+                continue;
+            }
+            let indices: Vec<&str> = line.split(' ').collect();
+            if indices.len() != 2 {
+                return Err(GraphError::ErrEdgeListLine {line: line.into()});
+            }
+            let src = match indices[0].parse::<usize>() {
+                Ok(idx) => idx,
+                Err(_) => return Err(GraphError::ErrEdgeIndexParse {edge_index: indices[0].into()}),
+            };
+            let dst = match indices[1].parse::<usize>() {
+                Ok(idx) => idx,
+                Err(_) => return Err(GraphError::ErrEdgeIndexParse {edge_index: indices[1].into()}),
+            };
+            edges.push(Edge(min(src, dst), max(src, dst)));
+        }
+        let min_index = edges.iter().map(|e| e.0).min().unwrap();
+        let max_index = edges.iter().map(|e| e.1).max().unwrap();
+        let n;
+        if min_index == 0 {
+            n = max_index + 1;
+        } else if min_index == 1 {
+            // Fix 1-indexing.
+            n = max_index;
+            edges = edges.iter().map(|e| Edge(e.0 - 1, e.1 - 1)).collect();
+        } else {
+            return Err(GraphError::ErrEdgeIndexMinimumValue {value: min_index});
+        }
+        edges.sort();
+        let mut edges_start = Vec::<usize>::new();
+        let mut neighbors = vec![Vec::<usize>::new(); n];
+        let mut src = edges[0].0;
+        edges_start.push(0);
+        for (idx, edge) in edges.iter().enumerate() {
+            if edge.0 != src {
+                // Handle implicit nodes with no edges.
+                for _ in src..edge.0 {
+                    edges_start.push(idx);
+                }
+                src = edge.0;
+            }
+            if neighbors[edge.0].contains(&edge.1) {
+                return Err(GraphError::ErrDuplicateEdge {e0: edge.0 + 1, e1: edge.1 + 1} );
+            }
+            neighbors[edge.0].push(edge.1);
+            neighbors[edge.1].push(edge.0);
+        }
+        // Handle implicit nodes with no edges.
+        for _ in src..n - 1 {
+            edges_start.push(edges.len());
+        }
+
+        let mut parsed_pops = Vec::<u32>::with_capacity(neighbors.len());
+        for pop in populations.replace('\n', "").split(' ') {
+            match pop.parse::<u32>() {
+                Ok(parsed) => parsed_pops.push(parsed),
+                Err(_) => return Err(GraphError::ErrPopulationParse {pop: pop.into()}),
+            }
+        }
+        if parsed_pops.len() != neighbors.len() {
+            return Err(GraphError::ErrNodeLengthMismatch {edge_list_nodes: neighbors.len(), pop_list_nodes: parsed_pops.len()});
+        }
+
+        Ok(Graph {
+            total_pop: parsed_pops.iter().sum(),
+            pops: parsed_pops,
+            neighbors: neighbors,
+            edges: edges,
+            edges_start: edges_start,
+            attr: HashMap::new(),
+        })
+    }
+}
+
+// functions/methods implemented for rust and for Python
+#[pymethods]
+impl Graph {
+    // This is the Python __new__ method for the wrapped class
+    # [new]
+    fn new (n: usize) -> PyResult<Self> {
+        Ok(Graph::new_buffer(n))
+    }
+
+    #[staticmethod]
+    #[args(name="from_edge_list")]
+    fn from_edge_list_py(edge_list: &str, populations: &str) -> PyResult<Self> {
+        return match Graph::from_edge_list(edge_list, populations) {
+            Ok(parsed_graph) => Ok(parsed_graph),
+            Err(graph_error) => Err(graph_error.into()),
+        }
+    }
+
     /// Resets a graph's containers.
     /// (Useful when using a graph as a subgraph buffer.)
     pub fn clear(&mut self) {
@@ -203,6 +252,12 @@ impl Graph {
         self.edges_start.fill(0);
         self.total_pop = 0;
     }
+}
+
+pub(crate) fn init_submodule (module: &PyModule) -> PyResult<()>  {
+    module.add_class::<Edge>()?;
+    module.add_class::<Graph>()?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-//! Library definition for frcw.
+use pyo3::prelude::*;
+
+/// Library definition for frcw. This is for usage by rust (such as src/bin files)
 mod buffers;
 pub mod config;
 pub mod graph;
@@ -7,3 +9,12 @@ pub mod partition;
 pub mod recom;
 mod spanning_tree;
 pub mod stats;
+
+/// This is collecting all of our wrapped functions to be exposed in the python module
+#[pymodule]
+fn frcw(py: Python, module: &PyModule) -> PyResult<()> {
+    // add graph to the top-level module
+    graph::init_submodule(module)?;
+
+    Ok(())
+}


### PR DESCRIPTION
One of the things that I discussed with @InnovativeInventor at https://github.com/mggg/GerryChain/discussions/379 was to make it easier to use frcw from python. As I mentioned there, I have some experience with wrapping Rust to make it available to Python.

This PR is meant to create discussion around this wrapping idea:
* is it worthwhile?
* does it avoid needing pcompress to go between GerryChain and frcw? Saving any trips to/from disk can be a big win.
* What is the minimum viable amount of wrapping to make this useful?
* What would a "dream/complete" wrapping look like? 
* How do we avoid code duplication (and perhaps also functionality divergence) between here and GerryChain, while also not requiring people to write Rust to test their new ideas?

Note that I changed the error handling for graph-related errors. This is hopefully a nice change from the string errors that are more annoying to catch and deal with. It makes error handling for the PyO3 wrapping stuff easier, too.

There's a lot of nitty-gritty details around mutability, ownership/references/copies, etc. that I haven't spent time examining yet. My Rust is rusty, and was never great to begin with, so I've mostly been just trying to get a simple PoC working.

You can test this from the frcw.rs root folder:

```
pip install maturin
maturin develop
python -c "import frcw; g=frcw.Graph(10); g.edges_start"
```