### PR TITLE
Fix pcompress writing bug

### DIFF
--- a/src/bin/frcw.rs
+++ b/src/bin/frcw.rs
@@ -201,6 +201,9 @@ fn main() {
             .unwrap()
             .insert("region_weights".to_string(), json!(region_weights));
     }
-    println!("{}", json!({ "meta": meta }).to_string());
+    if writer_str != "pcompress" { // hotfix for pcompress writing
+        // TODO: move this into init
+        println!("{}", json!({ "meta": meta }).to_string());
+    }
     multi_chain(&graph, &partition, writer, &params, n_threads, batch_size);
 }


### PR DESCRIPTION
This is a hotfix to get `pcompress` serialization working. Ideally, line 204 should be moved into the `init` of each `StatsWriter` (so each stats writer gets to control how the metadata is stored).